### PR TITLE
Fix for "load" closure not being called.

### DIFF
--- a/Survata.podspec
+++ b/Survata.podspec
@@ -2,10 +2,10 @@ Pod::Spec.new do |s|
   s.name             = "Survata"
   s.version          = "1.0.0"
   s.summary          = "Survata SDK"
-  s.homepage         = "https://github.com/greycats/survata-ios-sdk"
+  s.homepage         = "https://github.com/Survata/survata-ios-public-sdk"
   s.license          = 'MIT'
   s.author           = { "Rex Sheng" => "https://github.com/b051" }
-  s.source           = { :git => "https://github.com/greycats/survata-ios-sdk.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/Survata/survata-ios-public-sdk.git", :tag => s.version.to_s }
   s.requires_arc     = true
   s.platform         = :ios, "8.0"
   s.source_files     = "Survata/*.swift"

--- a/Survata/Survey.swift
+++ b/Survata/Survey.swift
@@ -257,9 +257,6 @@ class SurveyView: UIView, WKScriptMessageHandler {
 		webView.scrollView.showsVerticalScrollIndicator = false
 		webView.scrollView.showsHorizontalScrollIndicator = false
 		self.webView = webView
-		on("load") {[weak bar] _ in
-			bar?.hidden = false
-		}
 	}
 
 	deinit {
@@ -340,6 +337,7 @@ class SurveyViewController: UIViewController {
 			self?.survey.print("data \(data)")
 			if let data = data as? [String: AnyObject] {
 				if data["status"] as? String == "monetizable" {
+                    surveyView.topBar?.hidden = false
 					//continue
 				} else {
 					self?.dismissViewControllerAnimated(true, completion: nil)

--- a/Survata/Survey.swift
+++ b/Survata/Survey.swift
@@ -228,7 +228,7 @@ class SurveyView: UIView, WKScriptMessageHandler {
 		bar.translatesAutoresizingMaskIntoConstraints = false
 		addSubview(bar)
 		bar.fullWidth()
-		bar.fixAttribute(.Height, value: 39)
+		bar.fixAttribute(.Height, value: 64)
 		bar.toTheTop()
 		topBar = bar
 
@@ -236,10 +236,10 @@ class SurveyView: UIView, WKScriptMessageHandler {
 		closeButton.opaque = false
 		closeButton.translatesAutoresizingMaskIntoConstraints = false
 		bar.addSubview(closeButton)
-		closeButton.fixAttribute(.Width, value: 39)
-		closeButton.fixAttribute(.Height, value: 39)
+        closeButton.fixAttribute(.Width, value: 42)
+        closeButton.fixAttribute(.Height, value: 42)
 		closeButton.toTheRight()
-		closeButton.toTheTop()
+		closeButton.toTheBottom()
 		self.closeButton = closeButton
 		bar.hidden = true
 
@@ -306,7 +306,7 @@ class SurveyViewController: UIViewController {
 	weak var surveyView: SurveyView!
 	weak var survey: Survey!
 
-	var margin: CGFloat = 5
+	var margin: CGFloat = 0
 	var onCompletion: ((SVSurveyResult) -> ())?
 
 	override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {


### PR DESCRIPTION
surveyView.on("load") in SurveyViewController was never being called because the closure was being set again in SurveyView. This was causing issues if the survey was not monetizable, since the SurveyViewController would never be dismissed automatically.

Also, the podspec was pointing to the old repo, (greycats) instead of the newer, publicly accessible repo.